### PR TITLE
Fallback value column

### DIFF
--- a/core/LineReader.js
+++ b/core/LineReader.js
@@ -81,7 +81,6 @@ GSReader.prototype.extractFromWorksheet = function(rawWorksheet, keyCol, valCol,
     let fallbackValIndex = -1;
     for (let i = 0; i < headers.length; i++) {
       const value = headers[i].value;
-
       if (value === keyCol) {
         keyIndex = i;
       }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ Gs2File.prototype.setEncoding = function(encoding) {
 }
 
 Gs2File.prototype.save = async function(outputPath, opts) {
+  console.log('saving ' + outputPath)
   const self = this
 
   opts = opts || {}

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ Gs2File.prototype.setValueCol = function(valueCol) {
   this._defaultValueCol = valueCol
 }
 
+Gs2File.prototype.setFallbackValueCol = function(valueCol) {
+  this._defaultFallbackValueCol = valueCol
+}
+
 Gs2File.prototype.setKeyCol = function(keyCol) {
   this._defaultKeyCol = keyCol
 }
@@ -40,6 +44,7 @@ Gs2File.prototype.save = async function(outputPath, opts) {
 
   let keyCol = opts.keyCol
   let valueCol = opts.valueCol
+  let fallbackValueCol = opts.fallbackValueCol
   let format = opts.format
   let encoding = opts.encoding
 
@@ -49,6 +54,10 @@ Gs2File.prototype.save = async function(outputPath, opts) {
 
   if (!valueCol) {
     valueCol = this._defaultValueCol
+  }
+
+  if (!fallbackValueCol) {
+    fallbackValueCol = this._defaultFallbackValueCol
   }
 
   if (!format) {
@@ -62,7 +71,7 @@ Gs2File.prototype.save = async function(outputPath, opts) {
     }
   }
 
-  const lines = await this._reader.select(keyCol, valueCol)
+  const lines = await this._reader.select(keyCol, valueCol, fallbackValueCol)
 
   if (lines) {
     const transformer = Transformer[format || 'android']

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ Gs2File.prototype.setEncoding = function(encoding) {
 }
 
 Gs2File.prototype.save = async function(outputPath, opts) {
-  console.log('saving ' + outputPath)
   const self = this
 
   opts = opts || {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "localize-with-spreadsheet-2",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.1",
+      "version": "3.0.0",
       "dependencies": {
         "google-spreadsheet": "3.1.15",
         "mkpath": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "main": "index.js",
   "dependencies": {
     "google-spreadsheet": "3.1.15",
-    "q": "0.9.2",
-    "mkpath": "0.1.0"
+    "mkpath": "0.1.0",
+    "q": "0.9.2"
   },
   "readmeFilename": "README.md",
   "scripts": {

--- a/tests/iOSTransformerTests.js
+++ b/tests/iOSTransformerTests.js
@@ -1,8 +1,6 @@
 var transformer = require("../core/Transformer.js")['ios']
 var EOL = require('../core/Constants').EOL
 
-console.log(EOL === "\n")
-
 exports.testComment = function(test) {
   var result = transformer.transformComment('un commentaire');
 


### PR DESCRIPTION
Problem: There are cases where some languages are not localized 100% which makes `LocalizedStringKey` not translated properly.

Solution: Add fallback language if the provided `valueCol` is `null`.

So I added `fallbackValueCol` in case `valueCol` is empty.

Here's how I'm using it.

![CleanShot 2021-09-28 at 22 50 33@2x](https://user-images.githubusercontent.com/11477718/135121699-61770fbf-95c9-4499-82e3-3b753c81ecba.jpg)


Feel free to disregard this change if not needed.